### PR TITLE
SRE-4136 update circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ version: "2.1"
 executors:
   python_test:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: cimg/python:3.7-stretch
   pre_commit_test:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: cimg/python:3.7-stretch
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install pre-commit==2.12.1
+      - run: pip install pre-commit==2.12.1
       - run: pre-commit install-hooks
 
       - save_cache:
@@ -44,7 +44,7 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install pre-commit==1.18.3
+      - run: pip install pre-commit==1.18.3
       - run:
           name: Run pre-commit tests
           command: pre-commit run --all-files
@@ -57,8 +57,8 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install -r requirements.txt
-      - run: sudo pip install -r requirements-dev.txt
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
       - run: AWS_DEFAULT_REGION=us-east-1 nosetests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ version: "2.1"
 executors:
   python_test:
     docker:
-      - image: cimg/python:3.7-stretch
+      - image: cimg/python:3.7
   pre_commit_test:
     docker:
-      - image: cimg/python:3.7-stretch
+      - image: cimg/python:3.7
 
 jobs:
 


### PR DESCRIPTION
Updates the image used in the CircleCI builds to `cimg/python:3.7` due to a deprecation warning with `circleci/python:3.7-stretch`