### PR TITLE
Feature/SRE-4393 add kms permissions to antivirus scanner

### DIFF
--- a/infrastructure/cleardata/prod/s3-clamscan/.terraform.lock.hcl
+++ b/infrastructure/cleardata/prod/s3-clamscan/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.2"
+  constraints = "~> 3.69"
+  hashes = [
+    "h1:lcSLAmkNM1FvNhqAEbh2oTZRqF37HKRh1Di8LvssYBY=",
+    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
+    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
+    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
+    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
+    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
+    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
+    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
+    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
+    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
+    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+  ]
+}

--- a/infrastructure/modules/s3-clamscan/main.tf
+++ b/infrastructure/modules/s3-clamscan/main.tf
@@ -1,6 +1,17 @@
 # The AWS partition (commercial or govcloud)
 data "aws_partition" "current" {}
 
+data "terraform_remote_state" "kms_master_key" {
+  backend = "s3"
+  config = {
+    region  = var.terraform_state_aws_region
+    bucket  = var.terraform_state_s3_bucket
+    key     = "${var.terraform_state_aws_profile}/${var.env_name}/kms-master-key/terraform.tfstate"
+    encrypt = true
+    profile = var.terraform_state_aws_profile
+  }
+}
+
 locals {
   lambda_package_key = var.lambda_package_key != null ? var.lambda_package_key : "${var.lambda_package}/${var.lambda_version}/${var.lambda_package}.zip"
 }

--- a/infrastructure/modules/s3-clamscan/publisher.tf
+++ b/infrastructure/modules/s3-clamscan/publisher.tf
@@ -53,7 +53,8 @@ data "aws_iam_policy_document" "main_publish" {
     effect = "Allow"
 
     actions = [
-      "kms:GenerateDataKey"
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
     ]
 
     resources = ["${data.terraform_remote_state.kms_master_key.outputs.key_arn["cmk-${var.env_name}"]}"]

--- a/infrastructure/modules/s3-clamscan/publisher.tf
+++ b/infrastructure/modules/s3-clamscan/publisher.tf
@@ -41,16 +41,28 @@ data "aws_iam_policy_document" "main_publish" {
     effect = "Allow"
 
     actions = [
-        "sqs:SendMessage"
+      "sqs:SendMessage"
     ]
 
     resources = [aws_sqs_queue.messages.arn]
   }
+  # Allow access to env specific KMS keys 
+  statement {
+    sid = "AccessKMS"
+
+    effect = "Allow"
+
+    actions = [
+      "kms:GenerateDataKey"
+    ]
+
+    resources = ["${data.terraform_remote_state.kms_master_key.outputs.key_arn["cmk-${var.env_name}"]}"]
+  }
 }
 
 resource "aws_iam_role" "main_publish" {
-  name                 = "lmbrole-${var.env_name}-s3-clamscan-publisher"
-  assume_role_policy   = data.aws_iam_policy_document.assume_role_publish.json
+  name               = "lmbrole-${var.env_name}-s3-clamscan-publisher"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_publish.json
   tags = {
     "name"      = "lmbrole-${var.env_name}-s3-clamscan-publisher"
     "app"       = "s3-clamscan"

--- a/infrastructure/modules/s3-clamscan/scanner.tf
+++ b/infrastructure/modules/s3-clamscan/scanner.tf
@@ -110,7 +110,8 @@ data "aws_iam_policy_document" "main_scan" {
     effect = "Allow"
 
     actions = [
-      "kms:GenerateDataKey"
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
     ]
 
     resources = ["${data.terraform_remote_state.kms_master_key.outputs.key_arn["cmk-${var.env_name}"]}"]

--- a/infrastructure/modules/s3-clamscan/scanner.tf
+++ b/infrastructure/modules/s3-clamscan/scanner.tf
@@ -103,11 +103,23 @@ data "aws_iam_policy_document" "main_scan" {
 
     resources = formatlist("%s/*", data.aws_s3_bucket.main_scan.*.arn)
   }
+
+  statement {
+    sid = "AccessKMS"
+
+    effect = "Allow"
+
+    actions = [
+      "kms:GenerateDataKey"
+    ]
+
+    resources = ["${data.terraform_remote_state.kms_master_key.outputs.key_arn["cmk-${var.env_name}"]}"]
+  }
 }
 
 resource "aws_iam_role" "main_scan" {
-  name                 = "lmbrole-${var.env_name}-s3-clamscan-scanner"
-  assume_role_policy   = data.aws_iam_policy_document.assume_role_scan.json
+  name               = "lmbrole-${var.env_name}-s3-clamscan-scanner"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_scan.json
   tags = {
     "name"      = "lmbrole-${var.env_name}-s3-clamscan-scanner"
     "app"       = "s3-clamscan"
@@ -185,10 +197,10 @@ resource "aws_lambda_function" "main_scan" {
 
   environment {
     variables = {
-      AV_DEFINITION_S3_BUCKET        = aws_s3_bucket.virus_definitions.id
-      AV_DEFINITION_S3_PREFIX        = var.lambda_package
-      AV_SCAN_BUCKET_NAME            = data.aws_s3_bucket.main_scan[0].id
-      SQS_QUEUE_URL                  = aws_sqs_queue.messages.url
+      AV_DEFINITION_S3_BUCKET = aws_s3_bucket.virus_definitions.id
+      AV_DEFINITION_S3_PREFIX = var.lambda_package
+      AV_SCAN_BUCKET_NAME     = data.aws_s3_bucket.main_scan[0].id
+      SQS_QUEUE_URL           = aws_sqs_queue.messages.url
     }
   }
 

--- a/infrastructure/modules/s3-clamscan/variables.tf
+++ b/infrastructure/modules/s3-clamscan/variables.tf
@@ -80,3 +80,18 @@ variable "av_scan_minutes" {
   default     = 1
   type        = number
 }
+
+variable "terraform_state_aws_profile" {
+  description = "The name of the AWS profile used to store Terraform remote state"
+  type        = string
+}
+
+variable "terraform_state_aws_region" {
+  description = "The AWS region of the S3 bucket used to store Terraform remote state"
+  type        = string
+}
+
+variable "terraform_state_s3_bucket" {
+  description = "The name of the S3 bucket used to store Terraform remote state"
+  type        = string
+}


### PR DESCRIPTION
Uses remote state to source the arn for environment kms key and adds kms:generatedatakey permission